### PR TITLE
fix(styling): replace CSS file with inline iframe styling

### DIFF
--- a/.changeset/poor-baths-shave.md
+++ b/.changeset/poor-baths-shave.md
@@ -1,0 +1,9 @@
+---
+"react-native-vimeo-bridge": patch
+---
+
+fix(styling): replace CSS file with inline iframe styling
+
+- Remove CSS file dependency causing webpack parse errors
+- Apply width/height styles directly via JavaScript after iframe loads
+- Improves package compatibility without requiring CSS loaders

--- a/.changeset/poor-baths-shave.md
+++ b/.changeset/poor-baths-shave.md
@@ -7,3 +7,4 @@ fix(styling): replace CSS file with inline iframe styling
 - Remove CSS file dependency causing webpack parse errors
 - Apply width/height styles directly via JavaScript after iframe loads
 - Improves package compatibility without requiring CSS loaders
+- Breaking Changes: The removal of `width`, `height`, `maxwidth`, `maxheight`, and `responsive` from VimeoPlayerOptions (https://github.com/vimeo/player.js/issues/38#issuecomment-242462979)

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -66,7 +66,7 @@ function App() {
     [player],
   );
 
-  const getPlayerInfo = async () => {
+  const getPlayerInfo = useCallback(async () => {
     try {
       const [videoId, title, url, width, height] = await Promise.all([
         player.getVideoId(),
@@ -93,7 +93,7 @@ function App() {
     } catch (error) {
       console.error('Error getting player info:', error);
     }
-  };
+  }, [player]);
 
   useVimeoEvent(player, 'playing', (data) => {
     console.log('playing', data);

--- a/src/VimeoPlayer.tsx
+++ b/src/VimeoPlayer.tsx
@@ -146,7 +146,15 @@ const VimeoPlayer = ({
                   player.on('bufferstart', sendMessage('bufferstart'));
                   player.on('bufferend', sendMessage('bufferend'));
                   player.on('error', sendMessage('error'));
-                  player.on('loaded', sendMessage('loaded'));
+                  player.on('loaded', (data) => {
+                    sendMessage('loaded')(data);
+                    
+                    const iframe = document.querySelector('iframe');
+                    if (iframe) {
+                      iframe.style.width = '100%';
+                      iframe.style.height = '100%';
+                    }
+                  });
                   player.on('durationchange', sendMessage('durationchange'));
                   player.on('fullscreenchange', sendMessage('fullscreenchange'));
                   player.on('qualitychange', sendMessage('qualitychange'));

--- a/src/VimeoPlayer.web.tsx
+++ b/src/VimeoPlayer.web.tsx
@@ -1,11 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 import { useWindowDimensions } from 'react-native';
 import WebVimeoPlayerController from './module/WebVimeoPlayerController';
+import { INTERNAL_SET_CONTROLLER_INSTANCE } from './symbol';
 import type { VimeoPlayerProps } from './types';
 import VimeoPlayerWrapper from './VimeoPlayerWrapper';
-
-import './styles.css';
-import { INTERNAL_SET_CONTROLLER_INSTANCE } from './symbol';
 
 const VimeoPlayer = ({ player, height = 200, width, style, iframeStyle }: VimeoPlayerProps) => {
   const containerRef = useRef<HTMLDivElement>(null);

--- a/src/module/WebVimeoPlayerController.ts
+++ b/src/module/WebVimeoPlayerController.ts
@@ -77,6 +77,17 @@ class WebVimeoPlayerController {
 
     this.player = new window.Vimeo.Player(containerId, options);
 
+    if (this.player) {
+      this.player.on('loaded', () => {
+        const iframe = container.querySelector('iframe');
+
+        if (iframe) {
+          iframe.style.width = '100%';
+          iframe.style.height = '100%';
+        }
+      });
+    }
+
     return this.player;
   }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,4 +1,0 @@
-iframe {
-  width: 100%;
-  height: 100%;
-}

--- a/src/types/vimeo.ts
+++ b/src/types/vimeo.ts
@@ -115,23 +115,25 @@ export interface VimeoPlayerOptions {
   color?: string | undefined;
   controls?: boolean | undefined;
   dnt?: boolean | undefined;
-  height?: number | undefined;
   interactive_params?: string | undefined;
   keyboard?: boolean | undefined;
   loop?: boolean | undefined;
-  maxheight?: number | undefined;
-  maxwidth?: number | undefined;
   muted?: boolean | undefined;
   pip?: boolean | undefined;
   playsinline?: boolean | undefined;
   portrait?: boolean | undefined;
-  responsive?: boolean | undefined;
   speed?: boolean | undefined;
   quality?: VimeoVideoQuality | undefined;
   texttrack?: string | undefined;
   title?: boolean | undefined;
   transparent?: boolean | undefined;
-  width?: number | undefined;
+
+  // NOTE - https://github.com/vimeo/player.js/issues/38#issuecomment-242462979
+  // maxheight?: number | undefined;
+  // maxwidth?: number | undefined;
+  // responsive?: boolean | undefined;
+  // width?: number | undefined;
+  // height?: number | undefined;
 }
 
 export interface VimeoPlayerEventMap {


### PR DESCRIPTION
- Remove CSS file dependency causing webpack parse errors
- Apply width/height styles directly via JavaScript after iframe loads
- Improves package compatibility without requiring CSS loaders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved build compatibility issues by removing external CSS dependency and applying iframe sizing styles directly via JavaScript.
  * Ensured embedded Vimeo iframes consistently fill their container by setting width and height styles programmatically after loading.

* **Refactor**
  * Updated internal logic to handle iframe styling without relying on CSS files.
  * Memoized the player info retrieval function for improved performance and stability in the example app.

* **Style**
  * Removed all iframe sizing rules from the stylesheet.

* **Chores**
  * Commented out and referenced deprecated dimension-related properties in player options for future clarification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->