### PR TITLE
docs(readme): add direct link to Expo Go demo in example section

### DIFF
--- a/.changeset/gentle-melons-arrive.md
+++ b/.changeset/gentle-melons-arrive.md
@@ -1,0 +1,5 @@
+---
+"react-native-vimeo-bridge": patch
+---
+
+docs(readme): add direct link to an Expo Go demo in the "Examples & Demo" section

--- a/README-ko_kr.md
+++ b/README-ko_kr.md
@@ -22,7 +22,7 @@ React Native에서 Vimeo 플레이어를 사용하기 위해 복잡한 설정과
 ### 예제 및 데모
 - [📁 예제 프로젝트](/example/) - 실제 구현 코드와 다양한 사용 사례
 - [🌐 웹 데모](https://react-native-vimeo-bridge-example.pages.dev/) - 브라우저에서 바로 체험
-- [🤖 Expo Go](https://snack.expo.dev/@harang/react-native-vimeo-bridge) - snack expo에서 바로 체험
+- [🤖 Expo Go](https://snack.expo.dev/@harang/react-native-vimeo-bridge) - Snack Expo에서 바로 체험
 
 <p align="center">
   <img src="./assets/example.gif" width="600" />

--- a/README-ko_kr.md
+++ b/README-ko_kr.md
@@ -22,6 +22,7 @@ React Native에서 Vimeo 플레이어를 사용하기 위해 복잡한 설정과
 ### 예제 및 데모
 - [📁 예제 프로젝트](/example/) - 실제 구현 코드와 다양한 사용 사례
 - [🌐 웹 데모](https://react-native-vimeo-bridge-example.pages.dev/) - 브라우저에서 바로 체험
+- [🤖 Expo Go](https://snack.expo.dev/@harang/react-native-vimeo-bridge) - snack expo에서 바로 체험
 
 <p align="center">
   <img src="./assets/example.gif" width="600" />

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ With the lack of actively maintained Vimeo player libraries for React Native, `r
 ### Examples & Demo
 - [📁 Example Project](/example/) - Real implementation code and various use cases
 - [🌐 Web Demo](https://react-native-vimeo-bridge-example.pages.dev/) - Try it in your browser
-- [🤖 Expo Go](https://snack.expo.dev/@harang/react-native-vimeo-bridge) - Try it in snack expo
+- [🤖 Expo Go](https://snack.expo.dev/@harang/react-native-vimeo-bridge) - Try it on Expo Snack
 
 <p align="center">
   <img src="./assets/example.gif" width="600" />

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ With the lack of actively maintained Vimeo player libraries for React Native, `r
 ### Examples & Demo
 - [📁 Example Project](/example/) - Real implementation code and various use cases
 - [🌐 Web Demo](https://react-native-vimeo-bridge-example.pages.dev/) - Try it in your browser
+- [🤖 Expo Go](https://snack.expo.dev/@harang/react-native-vimeo-bridge) - Try it in snack expo
 
 <p align="center">
   <img src="./assets/example.gif" width="600" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a direct link to an Expo Go demo in the "Examples & Demo" section of both the English and Korean README files, allowing users to try the library interactively in the Expo environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->