### PR TITLE
fix: register event listeners after Vimeo player is loaded

### DIFF
--- a/.changeset/honest-places-lick.md
+++ b/.changeset/honest-places-lick.md
@@ -1,0 +1,12 @@
+---
+"react-native-vimeo-bridge": patch
+---
+
+fix: register event listeners after Vimeo player is loaded
+
+- Move event listener registration inside 'loaded' callback to ensure proper timing
+- Emit 'loaded' event immediately when already triggered
+- Register other events only after player is fully initialized
+- Prevents race condition where useVimeoEvent subscribes before player is ready
+
+Fixes issue where dynamic event subscriptions were not working due to timing mismatch between player initialization and listener registration.

--- a/src/VimeoView.tsx
+++ b/src/VimeoView.tsx
@@ -65,7 +65,7 @@ function VimeoView({ player, height = 200, width = screenWidth, style, webViewPr
   const createPlayerHTML = useCallback(() => {
     const sourceUri = player.getSource();
 
-    if (!sourceUri) {
+    if (sourceUri === null) {
       return '<html><body><div style="width: 100%; height: 100%; display: flex; justify-content: center; align-items: center; color: #fff;">Invalid Vimeo URL</div></body></html>';
     }
 

--- a/src/VimeoView.web.tsx
+++ b/src/VimeoView.web.tsx
@@ -22,7 +22,6 @@ function VimeoView({ player, height = 200, width, style, iframeStyle }: VimeoVie
 
   useEffect(() => {
     const source = player.getSource();
-    const listeners = player.getListeners();
 
     if (isInitialized && containerRef.current && source) {
       const containerId = `vimeo-player`;
@@ -36,9 +35,26 @@ function VimeoView({ player, height = 200, width, style, iframeStyle }: VimeoVie
 
       const vimeoPlayer = playerRef.current?.getVimeoPlayer();
 
-      listeners.keys().forEach((event) => {
-        vimeoPlayer?.on(event, (data) => {
-          player.emit(event, data);
+      const listeners = player.getListeners();
+
+      vimeoPlayer?.on('loaded', (data) => {
+        const iframe = document.getElementById(containerId)?.querySelector('iframe');
+
+        if (iframe) {
+          iframe.style.width = '100%';
+          iframe.style.height = '100%';
+        }
+
+        if (listeners.has('loaded')) {
+          player.emit('loaded', data);
+        }
+
+        listeners.keys().forEach((event) => {
+          if (event !== 'loaded') {
+            vimeoPlayer?.on(event, (data) => {
+              player.emit(event, data);
+            });
+          }
         });
       });
 

--- a/src/hooks/useVimeoOEmbed.ts
+++ b/src/hooks/useVimeoOEmbed.ts
@@ -30,7 +30,7 @@ export type VimeoOEmbed = {
  * @param url - The URL of the Vimeo video.
  * @returns The oEmbed data, loading state, and error.
  */
-const useVimeoOEmbed = (url: string, params?: VimeoEmbedOptions) => {
+const useVimeoOEmbed = (url?: string | null, params?: VimeoEmbedOptions) => {
   const [oEmbed, setOEmbed] = useState<VimeoOEmbed | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -38,6 +38,10 @@ const useVimeoOEmbed = (url: string, params?: VimeoEmbedOptions) => {
   const oEmbedUrl = createVimeoOEmbedUrl(url, params);
 
   useEffect(() => {
+    if (!oEmbedUrl) {
+      return;
+    }
+
     const controller = new AbortController();
 
     setError(null);
@@ -72,9 +76,7 @@ const useVimeoOEmbed = (url: string, params?: VimeoEmbedOptions) => {
       }
     };
 
-    if (oEmbedUrl) {
-      fetchOEmbed();
-    }
+    fetchOEmbed();
 
     return () => {
       controller.abort();

--- a/src/module/VimeoPlayer.ts
+++ b/src/module/VimeoPlayer.ts
@@ -1,22 +1,21 @@
 import { INTERNAL_SET_CONTROLLER_INSTANCE } from '../symbol';
-import type { VimeoEmbedOptions, VimeoSource } from '../types';
+import type { VimeoEmbedOptions } from '../types';
 import type { EventCallback, VimeoPlayerEventMap } from '../types/vimeo';
-import { parseVimeoSource } from '../utils';
 import type WebVimeoPlayerController from './WebVimeoPlayerController';
 import type WebviewVimeoPlayerController from './WebviewVimeoPlayerController';
 
 class VimeoPlayer {
   private listeners: Map<keyof VimeoPlayerEventMap, Set<EventCallback>> = new Map();
-  private source: string | null;
+  private source: string | null | undefined;
   private options?: VimeoEmbedOptions;
   private controller: WebviewVimeoPlayerController | WebVimeoPlayerController | null = null;
 
-  constructor(source: VimeoSource, options?: VimeoEmbedOptions) {
-    this.source = parseVimeoSource(source);
+  constructor(source: string | null | undefined, options?: VimeoEmbedOptions) {
+    this.source = source;
     this.options = options;
   }
 
-  getSource(): string | null {
+  getSource(): string | null | undefined {
     return this.source;
   }
 

--- a/src/module/WebVimeoPlayerController.ts
+++ b/src/module/WebVimeoPlayerController.ts
@@ -77,17 +77,6 @@ class WebVimeoPlayerController {
 
     this.player = new window.Vimeo.Player(containerId, options);
 
-    if (this.player) {
-      this.player.on('loaded', () => {
-        const iframe = container.querySelector('iframe');
-
-        if (iframe) {
-          iframe.style.width = '100%';
-          iframe.style.height = '100%';
-        }
-      });
-    }
-
     return this.player;
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,8 @@ import type { EmbedOptions, VimeoPlayerEventMap } from './vimeo';
 
 export type VimeoSource =
   | string
+  | null
+  | undefined
   | {
       url: string;
     };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,11 @@
 import { VIMEO_VIDEO_URL_REGEX } from '../constants';
 import type { VimeoEmbedOptions, VimeoSource } from '../types';
 
-export const parseVimeoSource = (source: VimeoSource): string | null => {
+export const parseVimeoSource = (source: VimeoSource): string | null | undefined => {
+  if (!source) {
+    return;
+  }
+
   if (typeof source === 'string') {
     return VIMEO_VIDEO_URL_REGEX.test(source) ? source : null;
   }
@@ -9,7 +13,7 @@ export const parseVimeoSource = (source: VimeoSource): string | null => {
   return VIMEO_VIDEO_URL_REGEX.test(source.url) ? source.url : null;
 };
 
-export function createVimeoOEmbedUrl(url: string, params?: VimeoEmbedOptions): string {
+export function createVimeoOEmbedUrl(url?: string | null, params?: VimeoEmbedOptions): string {
   if (!url) {
     return '';
   }


### PR DESCRIPTION
- Move event listener registration inside 'loaded' callback to ensure proper timing
- Emit 'loaded' event immediately when already triggered
- Register other events only after player is fully initialized
- Prevents race condition where useVimeoEvent subscribes before player is ready

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Vimeo player event handling, ensuring event listeners are registered only after the player is fully loaded to prevent missed or failed event subscriptions.
  * Fixed an issue where invalid Vimeo URLs were not consistently detected.

* **Refactor**
  * Streamlined event listener setup and player initialization for better control and consistency across platforms.
  * Enhanced handling of optional or missing Vimeo source URLs throughout the player and embedding logic.

* **New Features**
  * Expanded support for nullable and undefined Vimeo source inputs, improving flexibility when embedding videos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->